### PR TITLE
Remove debugging Println

### DIFF
--- a/contig/contig.go
+++ b/contig/contig.go
@@ -144,7 +144,6 @@ func (c *Contig) RevComp() {
 	})
 	c.vector = v
 	c.Strand = -c.Strand
-	fmt.Println()
 }
 
 // Reverse reverses the Contig and its contained sequences.


### PR DESCRIPTION
Based on context this print statement looks like it was left over from a debugging session.
