### PR TITLE
G+C ratio, file name handling in seqstats

### DIFF
--- a/seqstats/seqstats.go
+++ b/seqstats/seqstats.go
@@ -68,7 +68,7 @@ func main() {
 	}
 
 	var b binStats
-	var ctr = map[string]int{"A": 0, "T": 0, "G": 0, "C": 0}
+	var ctr = map[string]int{"G": 0, "C": 0}
 	var seqlens []int
 	var seqstr string
 	sc := seqio.NewScanner(r)
@@ -107,7 +107,7 @@ func main() {
 	}
 
 	b.avg = float64(b.size) / float64(b.totSeqs)
-	b.perGC = float64(ctr["G"]+ctr["C"]) / float64(ctr["A"]+ctr["T"]+ctr["G"]+ctr["C"]) * 100
+	b.perGC = float64(ctr["G"]+ctr["C"]) / float64(b.size) * 100
 	// Print the statistics of the assembly as key:value pairs.
 	fmt.Printf("%+v\n", b)
 }

--- a/seqstats/seqstats.go
+++ b/seqstats/seqstats.go
@@ -68,18 +68,16 @@ func main() {
 	}
 
 	var b binStats
-	var ctr = map[string]int{"G": 0, "C": 0}
+	var ctr [256]int
 	var seqlens []int
-	var seqstr string
 	sc := seqio.NewScanner(r)
 	b.name = strings.TrimSuffix(filepath.Base(*ctgf), filepath.Ext(*ctgf))
 	b.min = MaxInt
 
 	for sc.Next() {
 		s := sc.Seq()
-		seqstr = s.(*linear.Seq).Seq.String()
-		for k := range ctr {
-			ctr[k] += strings.Count(seqstr, k)
+		for _, l := range s.(*linear.Seq).Seq {
+			ctr[l|' ']++ // Count lowercased letter.
 		}
 		b.totSeqs++
 		b.size += s.Len()
@@ -107,7 +105,7 @@ func main() {
 		csum = seqlens[i] + csum
 	}
 	b.avg = float64(b.size) / float64(b.totSeqs)
-	b.perGC = float64(ctr["G"]+ctr["C"]) / float64(b.size) * 100
+	b.perGC = float64(ctr['g']+ctr['c']) / float64(ctr['a']+ctr['t']+ctr['g']+ctr['c']) * 100
 	// Print the statistics of the assembly as key:value pairs.
 	fmt.Printf("%+v\n", b)
 }

--- a/seqstats/seqstats.go
+++ b/seqstats/seqstats.go
@@ -105,7 +105,6 @@ func main() {
 		}
 		csum = seqlens[i] + csum
 	}
-
 	b.avg = float64(b.size) / float64(b.totSeqs)
 	b.perGC = float64(ctr["G"]+ctr["C"]) / float64(b.size) * 100
 	// Print the statistics of the assembly as key:value pairs.

--- a/seqstats/seqstats.go
+++ b/seqstats/seqstats.go
@@ -74,6 +74,7 @@ func main() {
 	sc := seqio.NewScanner(r)
 	b.name = strings.TrimSuffix(filepath.Base(*ctgf), filepath.Ext(*ctgf))
 	b.min = MaxInt
+
 	for sc.Next() {
 		s := sc.Seq()
 		seqstr = s.(*linear.Seq).Seq.String()


### PR DESCRIPTION
@kortschak, I added G+C ratio to the list of DNA sequence statistics printed by seqstats, in addition, I used TrimSuffix instead of Split to handle file names of the form "a.b.c.d.ext" (the older version would just print "a", while the newer version correctly prints "a.b.c.d").