### PR TITLE
krishna,igor: ease processing command usage

### DIFF
--- a/igor/gffer/gffer.go
+++ b/igor/gffer/gffer.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ignore
-
 // gffer converts the JSON output of igor to GFF.
 package main
 

--- a/igor/seqer/seqer.go
+++ b/igor/seqer/seqer.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ignore
-
 // seqer returns multiple fasta sequences corresponding to feature intervals
 // described in the JSON output from igor. It will also produce fastq consensus
 // sequence output from one of MUSCLE or MAFFT.


### PR DESCRIPTION
This moves `matrix`, `gffer` and `seqer` into their own paths, which means they can be installed with:

```
go get github.com/biogo/examples/krishna/...
go get github.com/biogo/examples/igor/...
```

Also, `matrix` now takes a single `krishnaflags` string argument which allows arguments to be passed directly to `krishna` without altering the matrix.go source, e.g.:

```
matrix -thread=10 -krishnaflags="-filtid=0.9 -filtlen=200" *
```

Please take a look @luzengAdelaide

Fixes #7.